### PR TITLE
Use `exceptRange` for Yoda rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = {
     'no-useless-call': 'error',
     'no-useless-return': 'error',
     'no-with': 'error',
-    yoda: 'error',
+    // `exceptRange` because http://llewellynfalco.blogspot.com/2016/02/dont-use-greater-than-sign-in.html
+    yoda: ['error', 'never', { exceptRange: true }],
     strict: 'error',
     'no-undef-init': 'error',
     'no-use-before-define': ['error', 'nofunc'],


### PR DESCRIPTION
Llewellyn Falco makes an excellent argument for why to write things like `0 < x`.

Alternatively, since the default setting is "never", you could consider this a stylistic
rule, and argue that it should not be in this config at all. (Since only when setting it
to "always" is it preventing problems, but also those problems are already prevented
by the `no-cond-assign` rule.)